### PR TITLE
fix: use query params for heroes endpoint

### DIFF
--- a/src/rest/controllers/Heroes.ts
+++ b/src/rest/controllers/Heroes.ts
@@ -1,10 +1,10 @@
 import { prisma } from '../../../generated/prisma-client';
 
 export async function getAllHeroes(req, res) {
-  const { first, skip } = req.body;
+  const { first, skip } = req.query;
   const heroes = await prisma.heroes({
-    first,
-    skip,
+    first: parseInt(first),
+    skip: parseInt(skip),
   });
 
   res.send(heroes);


### PR DESCRIPTION
## Description

- use query params instead of body for heroes endpoint
