### PR TITLE
feat: query heroes with type [rest-api]

### DIFF
--- a/src/rest/controllers/Heroes.ts
+++ b/src/rest/controllers/Heroes.ts
@@ -1,11 +1,14 @@
 import { prisma } from '../../../generated/prisma-client';
+import { heroesWithTypes } from '../../utils/fragments';
 
 export async function getAllHeroes(req, res) {
   const { first, skip } = req.query;
-  const heroes = await prisma.heroes({
-    first: parseInt(first),
-    skip: parseInt(skip),
-  });
+  const heroes = await prisma
+    .heroes({
+      first: parseInt(first),
+      skip: parseInt(skip),
+    })
+    .$fragment(heroesWithTypes);
 
   res.send(heroes);
 }
@@ -13,15 +16,12 @@ export async function getAllHeroes(req, res) {
 export async function getHeroById(req, res) {
   try {
     const { id } = req.params;
-    const hero = await prisma.hero({
-      id,
-    });
-    const type = await prisma
+    const hero = await prisma
       .hero({
         id,
       })
-      .type();
-    res.send({ ...hero, type });
+      .$fragment(heroesWithTypes);
+    res.send(hero);
   } catch (e) {
     res.status(404).send(e.message);
   }

--- a/src/utils/fragments.ts
+++ b/src/utils/fragments.ts
@@ -1,0 +1,12 @@
+export const heroesWithTypes = `
+fragment HeroesWithTypes on Hero {
+  id
+  avatar_url
+  full_name
+  description
+  type {
+    id
+    name
+  }
+}
+`;


### PR DESCRIPTION
## Description

Changes applied to this PR are the response to the feedback provided by the candidate.

```"The basic endpoint (fetching all heroes data) returns objects without their types. I saw it as a good exercise in writing consecutive calls for user details and pinpointing when the app is initialized, but as far as I know, this is a situation that shouldn't happen on production. The less calls to api, the better."```

Because designs require to display `type` field in each heroes item on the list, candidates have to:
*1)* fetch list of heroes
*2)* for each hero from response fetch hero details with `/heroes/:id` endpoint, to get the hero type info.

After the changes, users will need only to use `/heroes` endpoint
