### PR TITLE
fix: add type field to POST /heroes

### DIFF
--- a/src/rest/controllers/Heroes.ts
+++ b/src/rest/controllers/Heroes.ts
@@ -35,12 +35,14 @@ export async function createHero(req: Request, res: Response) {
 
   if (full_name && type) {
     try {
-      const newHero = await prisma.createHero({
-        avatar_url,
-        full_name,
-        description,
-        type: { connect: { id: type } },
-      });
+      const newHero = await prisma
+        .createHero({
+          avatar_url,
+          full_name,
+          description,
+          type: { connect: { id: type } },
+        })
+        .$fragment(heroesWithTypes);
 
       res.send(newHero);
     } catch (e) {


### PR DESCRIPTION
## Ticket

https://netguru.atlassian.net/browse/FA-25

## Description

Adds a `type` field to POST heroes/ endpoint
