### PR TITLE
subject: added 404 error on hero not found type: fix

### DIFF
--- a/src/rest/controllers/Heroes.ts
+++ b/src/rest/controllers/Heroes.ts
@@ -22,6 +22,10 @@ export async function getHeroById(req: Request, res: Response) {
         id,
       })
       .$fragment(heroesWithTypes);
+
+    if (!hero) {
+      res.status(404).send('not found');
+    }
     res.send(hero);
   } catch (e) {
     res.status(404).send(e.message);


### PR DESCRIPTION
## Description

`/heroes/non-exising-id` instead of 404 returns 200 status with empty response

This PR fixes it. Thanks