### PR TITLE
[Fix/FA-102] - Create hero endpoint - Set empty description by default

### DIFF
--- a/src/rest/controllers/Heroes.ts
+++ b/src/rest/controllers/Heroes.ts
@@ -34,7 +34,7 @@ export async function getHeroById(req: Request, res: Response) {
 
 export async function createHero(req: Request, res: Response) {
   const {
-    body: { avatar_url, full_name, type, description },
+    body: { avatar_url, full_name, type, description = '' },
   } = req;
 
   if (full_name && type) {


### PR DESCRIPTION
## Ticket

https://netguru.atlassian.net/browse/FA-102

## Description

*Current behavior*: POST Create Hero endpoint returns an error when the description field is not passed in the body. 
*Expected behavior*: Endpoint should create a new hero with an empty description since it's an optional field.
